### PR TITLE
hotfix(be): trim markdown code block syntax for result json

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,8 +40,11 @@ async def analyze_youtube_comments(url: str):
         raise HTTPException(status_code=404, detail="No comments found for this video")
 
     # Generate result using AnswerGenerator with comments and likes
-    result = comment_analyzer.get_answer(comments_with_likes)
-
+    result = (
+        comment_analyzer.get_answer(comments_with_likes)
+        .strip("````json\n")
+        .strip("\n````")
+    )
     print(result)
 
     return {"result": result}


### PR DESCRIPTION
## 설명

<!-- PR이 해결하고자 하는 문제를 설명합니다. -->

`/analyze` api에 request를 날리면 result에 markdown code block syntax인 ```가 들어가서, 해당 syntax를 trim해주는 기능을 추가했습니다.

## 테스트 방법

<!-- 리뷰어가 테스트해볼 수 있는 방법을 설명합니다. -->

`uvicorn main:app --host=0.0.0.0 --port=8000`

`http://localhost:8000/docs` swagger에서 테스트를 합니다.

localhost:
## 체크리스트

- [x] 스타일 가이드를 따르고 있습니다.
- [x] 스스로 코드를 검토하고 오타를 수정하였습니다.
- [x] 이해하기 어려운 부분이 있는지 확인하고 필요한 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warnings)가 발생하지 않습니다.
